### PR TITLE
Update source repository to use HTTPS

### DIFF
--- a/static-hash.cabal
+++ b/static-hash.cabal
@@ -18,4 +18,4 @@ library
   Build-Depends:        base >= 4 && < 5, primes, hashable, array, containers
 Source-Repository head
   Type:                 git
-  Location:             git://github.com/kazu-yamamoto/static-hash.git
+  Location:             https://github.com/kazu-yamamoto/static-hash.git


### PR DESCRIPTION
`git://` is no longer supported